### PR TITLE
AMP-65707 add the custom logic for the JSONata for AdapterV2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /Study.txt
 /.idea/*
 !/.idea/workspace.xml
-/JSONata4Java.iml
+*.iml
 /setupenv.cmd
+/out

--- a/src/main/java/com/api/jsonata4java/expressions/utils/FunctionUtils.java
+++ b/src/main/java/com/api/jsonata4java/expressions/utils/FunctionUtils.java
@@ -337,7 +337,7 @@ public class FunctionUtils implements Serializable {
                 }
                 case STRING:
                 default: {
-                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.asText());
+                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.toString());
                     TerminalNodeImpl tn = new TerminalNodeImpl(token);
                     StringContext sc = new MappingExpressionParser.StringContext(ctx);
                     sc.addAnyChild(tn);
@@ -465,7 +465,7 @@ public class FunctionUtils implements Serializable {
                 }
                 case STRING:
                 default: {
-                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, fieldObj.asText());
+                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, fieldObj.toString());
                     tn = new TerminalNodeImpl(token);
                     StringContext sc = new StringContext(ctx);
                     sc.addAnyChild(tn);
@@ -720,7 +720,7 @@ public class FunctionUtils implements Serializable {
                 }
                 case STRING:
                 default: {
-                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.asText());
+                    token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.toString());
                     TerminalNodeImpl tn = new TerminalNodeImpl(token);
                     StringContext sc = new StringContext(ctx);
                     sc.addAnyChild(tn);
@@ -815,7 +815,7 @@ public class FunctionUtils implements Serializable {
             }
             case STRING:
             default: {
-                token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.asText());
+                token = CommonTokenFactory.DEFAULT.create(MappingExpressionParser.STRING, element.toString());
                 TerminalNodeImpl tn = new TerminalNodeImpl(token);
                 StringContext sc = new StringContext(ctx);
                 sc.addAnyChild(tn);


### PR DESCRIPTION
This is the PR to get adapter V2 backward-compatible for JSONata.

I will open an issue to public repo so they can see whether to merge it or not. this one: https://github.com/IBM/JSONata4Java/issues/240 

Related PR on Adapter V2 side (which is verified working for our use case): https://github.com/amplitude/nova/pull/10883 